### PR TITLE
Add Rendering Options for Flot

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,8 +1,8 @@
 {
   "name": "backshift",
   "description": "Time series graphing",
-  "version": "1.0.1-beta.5",
-  "homepage": "https://github.com/j-white/backshift",
+  "version": "1.0.1-beta.7",
+  "homepage": "https://github.com/OpenNMS/backshift",
   "private": true,
   "main": [
     "dist/backshift.min.js"

--- a/package.json
+++ b/package.json
@@ -1,11 +1,11 @@
 {
   "name": "backshift",
-  "version": "1.0.1-beta.5",
+  "version": "1.0.1-beta.7",
   "repository": {
     "type": "git",
-    "url": "https://github.com/j-white/backshift.git"
+    "url": "https://github.com/OpenNMS/backshift.git"
   },
-  "homepage": "https://github.com/j-white/backshif",
+  "homepage": "https://github.com/OpenNMS/backshift",
   "devDependencies": {
     "grunt": "~0.4.5",
     "grunt-contrib-jshint": "~0.11.2",

--- a/src/Backshift.Graph.Flot.js
+++ b/src/Backshift.Graph.Flot.js
@@ -13,7 +13,10 @@ Backshift.Graph.Flot = Backshift.Class.create(Backshift.Graph, {
       height: '100%',
       title: undefined,
       verticalLabel: undefined,
-      zoom: true // whether to allow zooming
+      zoom: true, // whether to allow zooming
+      xaxisFont: undefined, // flot "font" spec, see http://flot.googlecode.com/svn/trunk/API.txt for details
+      yaxisFont: undefined, // flot "font" spec
+      legendFontSize: undefined, // font size (integer)
     });
   },
 
@@ -182,7 +185,52 @@ Backshift.Graph.Flot = Backshift.Class.create(Backshift.Graph, {
 
     this.addTimeAxis(options, from, to);
 
+    if (self.xaxisFont) {
+      options.xaxis.font = self.getFontSpec(self.xaxisFont);
+    }
+    if (self.yaxisFont) {
+      options.yaxis.font = self.getFontSpec(self.yaxisFont);
+    }
+    if (self.legendFontSize) {
+      if (!options.legend.style) {
+        options.legend.style = {};
+      }
+      options.legend.style.fontSize = this.legendFontSize;
+    }
+
     jQuery.plot(container, this.flotSeries, options);
+  },
+
+  getFontSpec: function(fontSpec) {
+    var ret = {
+      size: 'inherit',
+      family: 'inherit',
+      style: 'inherit',
+      weight: 'inherit',
+      variant: 'inherit',
+      color: 'inherit',
+    };
+    if (fontSpec) {
+      if (fontSpec.size) {
+        ret.size = fontSpec.size;
+      }
+      if (fontSpec.family) {
+        ret.family = fontSpec.family;
+      }
+      if (fontSpec.style) {
+        ret.style = fontSpec.style;
+      }
+      if (fontSpec.weight) {
+        ret.weight = fontSpec.weight;
+      }
+      if (fontSpec.variant) {
+        ret.variant = fontSpec.variant;
+      }
+      if (fontSpec.color) {
+        ret.color = fontSpec.color;
+      }
+    }
+    return ret;
   },
 
   drawHook: function(plot, canvascontext) {

--- a/src/Backshift.Graph.Flot.js
+++ b/src/Backshift.Graph.Flot.js
@@ -17,6 +17,7 @@ Backshift.Graph.Flot = Backshift.Class.create(Backshift.Graph, {
       xaxisFont: undefined, // flot "font" spec, see http://flot.googlecode.com/svn/trunk/API.txt for details
       yaxisFont: undefined, // flot "font" spec
       legendFontSize: undefined, // font size (integer)
+      ticks: undefined, // number of x-axis ticks, defaults to a value based on the width
     });
   },
 
@@ -242,7 +243,7 @@ Backshift.Graph.Flot = Backshift.Class.create(Backshift.Graph, {
 
   addTimeAxis: function(options, from, to) {
     var elem = jQuery(this.element);
-    var ticks = elem.width() / 100;
+    var ticks = this.ticks || (elem.width() / 100);
 
     options.xaxis = {
       mode: "time",


### PR DESCRIPTION
This pull request adds support for exposing a couple of configurations to the underlying Flot renderer:

* xaxisFont/yaxisFont: (object) a Flot font-spec object to pass to the axis options
* legendFontSize: (number) the font size to pass to the Flot legend plugin
* ticks: (number) specify the number of (x-axis) ticks to attempt to render

For details, see the Flot API docs here: https://github.com/flot/flot/blob/master/API.md#customizing-the-axes