### PR TITLE
allow render with empty data

### DIFF
--- a/src/Backshift.Graph.Flot.js
+++ b/src/Backshift.Graph.Flot.js
@@ -42,6 +42,10 @@ Backshift.Graph.Flot = Backshift.Class.create(Backshift.Graph, {
     this.drawChart(results);
   },
 
+  onRender: function() {
+    this.drawChart();
+  },
+
   _shouldStack: function (k) {
     // If there's stack following the area, set the area to stack
     if (this.model.series[k].type === "area") {
@@ -59,13 +63,19 @@ Backshift.Graph.Flot = Backshift.Class.create(Backshift.Graph, {
     var self = this;
     var container = jQuery(this.element);
 
-    var timestamps = results.columns[0];
-    var series, values, i, j, numSeries, numValues, X, Y, columnName, shouldStack, shouldFill, seriesValues, shouldShow;
+    var timestamps = [];
+    if (results && results.columns) {
+      timestamps = results.columns[0];
+    }
+    var series = {}, values, i, j, numSeries, numValues, X, Y, columnName, shouldStack, shouldFill, seriesValues, shouldShow;
     numSeries = this.model.series.length;
     numValues = timestamps.length;
 
-    var from = timestamps[0];
-    var to = timestamps[timestamps.length - 1];
+    var from, to;
+    if (numValues >= 2) {
+      from = timestamps[0];
+      to = timestamps[timestamps.length - 1];
+    }
 
     this.flotSeries = [];
     this.hiddenFlotSeries = [];
@@ -76,7 +86,9 @@ Backshift.Graph.Flot = Backshift.Class.create(Backshift.Graph, {
     for (i = 0; i < numSeries; i++) {
       columnName = "data" + i;
       series = this.model.series[i];
-      values = results.columns[results.columnNameToIndex[series.metric]];
+      if (series.metric && results && results.columns) {
+        values = results.columns[results.columnNameToIndex[series.metric]];
+      }
 
       shouldStack = this._shouldStack(i);
       shouldFill = this.model.series[i].type === "stack" || this.model.series[i].type === "area";
@@ -122,7 +134,7 @@ Backshift.Graph.Flot = Backshift.Class.create(Backshift.Graph, {
 
     var options = {
       canvas: true,
-      title: self.title,
+      title: self.title || '',
       axisLabels: {
         show: true
       },
@@ -150,7 +162,7 @@ Backshift.Graph.Flot = Backshift.Class.create(Backshift.Graph, {
       },
       yaxes: [{
         position: 'left',
-        axisLabel: self.verticalLabel,
+        axisLabel: self.verticalLabel || '',
         axisLabelUseHtml: false,
         axisLabelUseCanvas: true
       }],


### PR DESCRIPTION
This patch gives the Flot renderer the same behavior I had for the DC renderer, ie, it can render an empty graph immediately, and then can later be updated/re-rendered when data is available.

This allows me to throw-away data for graphs that are not visible in the UI in Compass, to save memory.
