### PR TITLE
clean up on destroy

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -19,7 +19,6 @@ module.exports = function (grunt) {
     'src/Backshift.DataSource.NRTG.js',
     'src/Backshift.Legend.js',
     'src/Backshift.Legend.Rickshaw.js',
-    'src/Backshift.Graph.js',
     'src/Backshift.Graph.Matrix.js',
     'src/Backshift.Graph.Flot.js',
     'src/Backshift.Graph.Rickshaw.js',

--- a/src/Backshift.Graph.C3.js
+++ b/src/Backshift.Graph.C3.js
@@ -123,6 +123,9 @@ Backshift.Graph.C3 = Backshift.Class.create(Backshift.Graph, {
   },
 
   onQuerySuccess: function (results) {
+    if (!results || !results.columns) {
+      return;
+    }
     var timestamps = results.columns[0];
     var series, values, i, j, numSeries, numValues, X, Y, columnName, shouldStack;
     numSeries = this.model.series.length;

--- a/src/Backshift.Graph.Flot.js
+++ b/src/Backshift.Graph.Flot.js
@@ -56,6 +56,10 @@ Backshift.Graph.Flot = Backshift.Class.create(Backshift.Graph, {
   },
 
   drawChart: function (results) {
+    if (!results || !results.columns) {
+      return;
+    }
+
     var self = this;
     var container = jQuery(this.element);
 

--- a/src/Backshift.Graph.Flot.js
+++ b/src/Backshift.Graph.Flot.js
@@ -222,11 +222,11 @@ Backshift.Graph.Flot = Backshift.Class.create(Backshift.Graph, {
       options.legend.style.fontSize = this.legendFontSize;
     }
 
-    var chart = jQuery.plot(container, this.flotSeries, options);
+    this.chart = jQuery.plot(container, this.flotSeries, options);
 
     // Limit the zooming and panning so that at least one point is always visible
-    var yaxis = chart.getAxes().yaxis;
-    chart.ranges = {
+    var yaxis = this.chart.getAxes().yaxis;
+    this.chart.ranges = {
       yaxis: { panRange: [yaxis.min, yaxis.max], zoomRange: false}, xaxis: { panRange: [from,to], zoomRange: null }
     };
   },
@@ -305,5 +305,12 @@ Backshift.Graph.Flot = Backshift.Class.create(Backshift.Graph, {
     }
 
     return "%H:%M";
+  },
+
+  onDestroy: function() {
+    if (this.chart && this.chart.destroy) {
+      this.chart.shutdown();
+      this.chart.destroy();
+    }
   }
 });

--- a/src/Backshift.Graph.js
+++ b/src/Backshift.Graph.js
@@ -88,6 +88,7 @@ Backshift.Graph = Backshift.Class.create(Backshift.Class.Configurable, {
 
   destroy: function() {
     this.destroyTimer();
+    this.onDestroy();
   },
 
   createTimer: function () {
@@ -276,6 +277,10 @@ Backshift.Graph = Backshift.Class.create(Backshift.Class.Configurable, {
   },
 
   onAfterQuery: function () {
+    // Implemented by subclasses
+  },
+
+  onDestroy: function () {
     // Implemented by subclasses
   }
 });


### PR DESCRIPTION
Flot will leak memory by leaving events attached to the DOM element associated with the graph unless you call chart.destroy().  This patch adds an "onDestroy()" method to the base Backshift graph class, and implements it in the Flot renderer.
