### PR TITLE
check for a canvas before redrawing

### DIFF
--- a/examples/opennms-graphs.html
+++ b/examples/opennms-graphs.html
@@ -71,6 +71,16 @@
 
     <div class="row">
         <div class="col-md-6">
+            <div data-graph-report="mib2.traffic-inout" data-graph-resource="node[71].interfaceSnmp[wireless_0-18cf5ebc49b9]"
+                 data-original-graph="rrda" data-graph-model="grapha"></div>
+        </div>
+        <div class="col-md-6">
+            <div id="rrda"></div>
+        </div>
+    </div>
+
+    <div class="row">
+        <div class="col-md-6">
             <div data-graph-report="lmsensors.fan" data-graph-resource="node[35].lmFanIndex[5]"
                  data-original-graph="rrd9" data-graph-model="graph9"></div>
         </div>

--- a/src/Backshift.Graph.Flot.js
+++ b/src/Backshift.Graph.Flot.js
@@ -30,23 +30,33 @@ Backshift.Graph.Flot = Backshift.Class.create(Backshift.Graph, {
 
   showStatus: function(text) {
     if (this.chart) {
-      var options = this.chart.getOptions();
-      if (!options._oldTitle) {
-        options._oldTitle = options.title;
+      var options = this.chart.getOptions(),
+        canvas = this.chart.getCanvas();
+      if (options) {
+        if (!options._oldTitle) {
+          options._oldTitle = options.title;
+        }
+        options.title = text;
+        if (options.canvas && canvas) {
+          this.chart.draw();
+        }
       }
-      options.title = text;
-      this.chart.draw();
     }
   },
 
   hideStatus: function() {
     if (this.chart) {
-      var options = this.chart.getOptions();
-      if (options._oldTitle) {
-        options.title = options._oldTitle;
-        delete options._oldTitle;
+      var options = this.chart.getOptions(),
+        canvas = this.chart.getCanvas();
+      if (options) {
+        if (options._oldTitle) {
+          options.title = options._oldTitle;
+          delete options._oldTitle;
+        }
+        if (options.canvas && canvas) {
+          this.chart.draw();
+        }
       }
-      this.chart.draw();
     }
   },
 


### PR DESCRIPTION
If a graph is in the middle of being torn down when a status update comes in, Backshift.Graph.Flot may try rendering after the canvas has already been destroyed.  This patch does a quick bounds-check to make sure it's there first.
